### PR TITLE
コンテナ内でgitを使えるようにした

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.10.0
 
 RUN apt update && \
+apt install -y git && \
 apt -y install locales && \
 localedef -f UTF-8 -i ja_JP ja_JP.UTF-8
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     ports:
       - 8000:8000
     volumes:
-      - .:/usr/src/app/
+      - ../:/usr/src/app/
     working_dir: "/usr/src/app"
     tty: true
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,4 +3,5 @@ FROM node:16-alpine3.11
 WORKDIR /app
 
 RUN apk update && \
+apk add git && \
 npm install -g @vue/cli

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     ports:
       - 8080:8080
     volumes:
-      - .:/app
+      - ../:/app
     tty: true
     


### PR DESCRIPTION
#11 
volumeをhomete/直下にすることで、.gitを含ませることができた。
コンテナにgitをインストールした。