### PR TITLE
ログイン画面のアイコンを修正した

### DIFF
--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -7,7 +7,7 @@
 			<v-card-text>
 				<v-form>
 					<v-text-field
-						prepend-icon="mdi-account-circle"
+						prepend-icon="mdi-email"
 						label="メールアドレス"
 						v-model="email"
 					/>


### PR DESCRIPTION
メールアドレスフォームに使用しているマテリアルデザインアイコンがユーザーを表すものになっていたため変更した
<img width="533" alt="スクリーンショット 2021-12-12 16 38 48" src="https://user-images.githubusercontent.com/60804269/145705195-2d0e4243-c367-40a0-a7b5-a4cb553b4632.png">
。