### PR TITLE
パスワード再設定用のページとメールアドレス要求ページを作成した

### DIFF
--- a/frontend/src/components/Requestmail.vue
+++ b/frontend/src/components/Requestmail.vue
@@ -1,0 +1,29 @@
+<template>
+	<v-card-text>
+		<v-form>
+			<v-text-field
+				prepend-icon="mdi-email"
+				label="メールアドレス"
+				v-model="email"
+			/>
+			<v-card-actions>
+					<v-btn
+						class="info ml-auto mt-5"
+						@click="submit">
+					送信
+					</v-btn>
+			</v-card-actions>
+		</v-form>
+	</v-card-text>
+</template>
+
+<script>
+export default{
+		name: 'Requestmail',
+		data(){
+			return{
+				email: '',
+			}
+		},
+}
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -27,7 +27,12 @@ const routes = [
     path: '/signup',
     name: 'Signup',
     component: () => import('../views/Signup.vue')
-  }
+  },
+  {
+    path: '/passreset',
+    name: 'Passreset',
+    component: () => import('../views/Passreset.vue')
+  },
 ]
 
 const router = new VueRouter({

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -33,6 +33,11 @@ const routes = [
     name: 'Passreset',
     component: () => import('../views/Passreset.vue')
   },
+  {
+    path: '/passreset_reqmail',
+    name: 'Passreset_reqmail',
+    component: () => import('../views/Passreset_reqmail.vue')
+  },
 ]
 
 const router = new VueRouter({

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -23,7 +23,7 @@
 						<div class="ic-Login__forgot ml-auto">
 							<a class="ic-Login__link forgot_password_link"
 								id="login_forgot_password"
-								href="#">
+								href="passreset_reqmail">
 							パスワードを忘れた場合
 							</a>
 						</div>

--- a/frontend/src/views/Passreset.vue
+++ b/frontend/src/views/Passreset.vue
@@ -1,0 +1,53 @@
+<template>
+	<v-app>
+		<v-card width="400px" class="mx-auto my-auto pa-3">
+			<v-card-title>
+				<h1 class="headline">パスワード再設定</h1>
+			</v-card-title>
+			<v-card-text>
+				<v-form>
+					<v-text-field
+						v-bind:type="showPassword ? 'text' : 'password'"
+						prepend-icon="mdi-lock"
+						v-bind:append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+						label="パスワード"
+						@click:append="showPassword = !showPassword"
+						v-model="password"
+					/>
+					<v-text-field
+						v-bind:type="showPasswordConfirmation ? 'text' : 'password'"
+						prepend-icon="mdi-lock"
+						v-bind:append-icon="showPasswordConfirmation ? 'mdi-eye' : 'mdi-eye-off'"
+						label="パスワード確認"
+						@click:append="showPasswordConfirmation = !showPasswordConfirmation"
+						v-model="password_confirmation"
+					/>
+					<v-card-actions>
+							<v-btn
+								class="info ml-auto mt-5"
+								@click="submit">
+							パスワードを再設定する
+							</v-btn>
+					</v-card-actions>
+				</v-form>
+			</v-card-text>
+		</v-card>
+	</v-app>
+</template>
+
+
+<script>
+	export default{
+		name: 'Passreset',
+		data(){
+			return{
+				showPassword: false,
+				showPasswordConfirmation: false,
+				password: '',
+				password_confirmation: '',
+			}
+		},
+		methods:{
+		},
+	}
+</script>

--- a/frontend/src/views/Passreset_reqmail.vue
+++ b/frontend/src/views/Passreset_reqmail.vue
@@ -3,38 +3,21 @@
 		<v-card width="400px" class="mx-auto my-auto pa-3">
 			<v-card-title>
 				<h1 class="headline">パスワード再設定</h1>
-				<p><font size="-1">ご利用中のメールアドレスを入力してください。パスワード再設定のためのURLをお送りします。</font></p>
+				<p><font size="-1">ご利用中のメールアドレスを入力してください。<br>パスワード再設定のためのURLをお送りします。</font></p>
 			</v-card-title>
-			<v-card-text>
-				<v-form>
-					<v-text-field
-						prepend-icon="mdi-email"
-						label="メールアドレス"
-						v-model="email"
-					/>
-					<v-card-actions>
-							<v-btn
-								class="info ml-auto mt-5"
-								@click="submit">
-							再設定メールを送信
-							</v-btn>
-					</v-card-actions>
-				</v-form>
-			</v-card-text>
+			<Requestmail />
 		</v-card>
 	</v-app>
 </template>
 
 
 <script>
+	import Requestmail from '../components/Requestmail'
+
 	export default{
 		name: 'Passreset_reqmail',
-		data(){
-			return{
-				email: '',
-			}
-		},
-		methods:{
+		components: {
+			Requestmail,
 		},
 	}
 </script>

--- a/frontend/src/views/Passreset_reqmail.vue
+++ b/frontend/src/views/Passreset_reqmail.vue
@@ -1,0 +1,40 @@
+<template>
+	<v-app>
+		<v-card width="400px" class="mx-auto my-auto pa-3">
+			<v-card-title>
+				<h1 class="headline">パスワード再設定</h1>
+				<p><font size="-1">ご利用中のメールアドレスを入力してください。パスワード再設定のためのURLをお送りします。</font></p>
+			</v-card-title>
+			<v-card-text>
+				<v-form>
+					<v-text-field
+						prepend-icon="mdi-email"
+						label="メールアドレス"
+						v-model="email"
+					/>
+					<v-card-actions>
+							<v-btn
+								class="info ml-auto mt-5"
+								@click="submit">
+							再設定メールを送信
+							</v-btn>
+					</v-card-actions>
+				</v-form>
+			</v-card-text>
+		</v-card>
+	</v-app>
+</template>
+
+
+<script>
+	export default{
+		name: 'Passreset_reqmail',
+		data(){
+			return{
+				email: '',
+			}
+		},
+		methods:{
+		},
+	}
+</script>


### PR DESCRIPTION
ログインページを参考にパスワード再設定用のページを作成した。
また、メールアドレスを要求するページを作成し、ログインページ内の「パスワードを忘れた場合」のhrefに入れて画面を遷移できるようにした
<img width="510" alt="スクリーンショット 2021-12-13 10 52 42" src="https://user-images.githubusercontent.com/60804269/145747740-54eb99ec-3004-4636-b99d-816d7e0c0a61.png">
<img width="511" alt="スクリーンショット 2021-12-13 11 11 00" src="https://user-images.githubusercontent.com/60804269/145747742-55b747d6-f73d-4cce-beb2-5f18c653e027.png">
。