### PR TITLE
コンテナの自動起動対策

### DIFF
--- a/backend/docker-compose.dev.yml
+++ b/backend/docker-compose.dev.yml
@@ -4,7 +4,6 @@ version: "3.8"
 services:
   redis:
     container_name: "redis"
-    restart: always
     networks:
       - homete_network
     image: "redis"
@@ -15,7 +14,6 @@ services:
 
   mysql:
     container_name: "mysql"
-    restart: always
     networks:
       - homete_network
     image: mysql
@@ -32,7 +30,6 @@ services:
 
   python:
     container_name: "python3"
-    restart: always
     networks:
       - homete_network
     build:


### PR DESCRIPTION
開発用PCでコンテナが自動起動されてしまうのでbackend/docker-compose.ymのrestart: alwaysを削除