### PR TITLE
コンテナ内のnode_modulesが空になる問題を解決

### DIFF
--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - 8080:8080
     volumes:
       - .:/app
+      - /app/node_modules
     working_dir: "/app"
     tty: true
     environment:


### PR DESCRIPTION
docker buildでnpm installしてるのにコンテナ内のnode_modulesが空になっていたので修正
**解決策**
https://qiita.com/P-man_Brown/items/5a82ad98cb96206343b9

**古いブランチでエラーが発生してる場合**
```bash
# docker-compose.ymlの entrypoint: npm run serve をコメントアウトします

make up
make exec

npm install # コンテナのターミナル内で実行
exit # コンテナのターミナルから抜け出す
docker-compose down

# docker-compose.ymlのコメントアウトした部分を元に戻し

make up
# これで正常動作するはずです。お疲れ様でした。
```

**developから新しく生やすブランチで作業する場合**
```bash
sudo rm -rf node_modules/
docker-compose build --no-cache
make up
#ここでからのnode_modulesが生成されます
#以降はnode_modules消さなくて大丈夫です
```