### PR TITLE
全体的にデザインをモックに合わせて変更

### DIFF
--- a/frontend/src/components/leftMenu/LeftMenu.vue
+++ b/frontend/src/components/leftMenu/LeftMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <v-col class="leftMenu">
-    <div class="sideMenuButton">
+    <div class="leftMenuFlex">
       <LeftMenuButton
         usage="alertPost"
         btnText="タイムライン"
@@ -15,18 +15,19 @@
   </v-col>
 </template>
 <style>
-.leftMenu{
-  width: 100%;
-  height: 80vh;
-  min-height: 80vh;
-  max-height: 80vh;
+.leftMenu {
+  display: flex;
+  height: 100vh;
+  min-height: 100vh;
+  max-height: 100vh;
   margin: 0;
   padding: 0;
 }
-.sideMenuButton {
+.leftMenuFlex {
   display: flex;
   flex-flow: column;
-  z-index: 100;
+  gap: 40px;
+  margin: auto 0;
 }
 </style>
 

--- a/frontend/src/components/leftMenu/LeftMenu.vue
+++ b/frontend/src/components/leftMenu/LeftMenu.vue
@@ -32,48 +32,12 @@
 </style>
 
 <script>
-import axios from "axios";
 import LeftMenuButton from "./LeftMenuButton.vue";
 
 export default {
-  name: "SideMenu",
-  computed: {
-    isVisiblePostHomete() {
-      return this.$store.getters.isVisiblePostHomete;
-    },
-  },
+  name: "LeftMenu",
   components: {
     LeftMenuButton,
-  },
-  methods: {
-    alertPostVisible: function () {
-      this.$store.dispatch(this.t[0]);
-    },
-    visibleCard: function () {
-      this.alertPostVisible();
-      this.$store.dispatch("toVisiblePostHomete");
-    },
-    logout: function () {
-      axios
-        .post(
-          "/user/logout",
-          {
-            //
-          },
-          {
-            withCredentials: true,
-          }
-        )
-        .then((res) => {
-          console.log(res);
-          if (res.status == 200) {
-            this.$emit("logout");
-          }
-        })
-        .catch((err) => {
-          console.log(err);
-        });
-    },
   },
 };
 </script>

--- a/frontend/src/components/leftMenu/LeftMenu.vue
+++ b/frontend/src/components/leftMenu/LeftMenu.vue
@@ -1,29 +1,32 @@
 <template>
-  <v-col class="ma-0 pa-0">
-    <v-container class="sideContainer">
-      <v-row justify="start" class="mt-7 sideMenuButton">
-        <LeftMenuButton
-          usage="alertPost"
-          btnText="タイムライン"
-          btnIcon="mdi-home"
-        />
-        <LeftMenuButton
-          usage="alertLogin"
-          btnText="ヒストリー"
-          btnIcon="mdi-history"
-        />
-      </v-row>
-    </v-container>
+  <v-col class="leftMenu">
+    <div class="sideMenuButton">
+      <LeftMenuButton
+        usage="alertPost"
+        btnText="タイムライン"
+        btnIcon="mdi-home"
+      />
+      <LeftMenuButton
+        usage="alertLogin"
+        btnText="ヒストリー"
+        btnIcon="mdi-history"
+      />
+    </div>
   </v-col>
 </template>
 <style>
-.sideContainer {
+.leftMenu{
+  position: fixed;
+  width: 100%;
   height: 100vh;
+  margin: 0;
+  padding: 0;
 }
 .sideMenuButton {
   position: relative;
   z-index: 100;
-  margin-bottom: 5pt;
+  display: flex;
+  flex-flow: column;
 }
 </style>
 

--- a/frontend/src/components/leftMenu/LeftMenu.vue
+++ b/frontend/src/components/leftMenu/LeftMenu.vue
@@ -2,12 +2,12 @@
   <v-col class="leftMenu">
     <div class="leftMenuFlex">
       <LeftMenuButton
-        usage="alertPost"
+        usage=""
         btnText="タイムライン"
         btnIcon="mdi-home"
       />
       <LeftMenuButton
-        usage="alertLogin"
+        usage=""
         btnText="ヒストリー"
         btnIcon="mdi-history"
       />

--- a/frontend/src/components/leftMenu/LeftMenu.vue
+++ b/frontend/src/components/leftMenu/LeftMenu.vue
@@ -16,17 +16,17 @@
 </template>
 <style>
 .leftMenu{
-  position: fixed;
   width: 100%;
-  height: 100vh;
+  height: 80vh;
+  min-height: 80vh;
+  max-height: 80vh;
   margin: 0;
   padding: 0;
 }
 .sideMenuButton {
-  position: relative;
-  z-index: 100;
   display: flex;
   flex-flow: column;
+  z-index: 100;
 }
 </style>
 

--- a/frontend/src/components/leftMenu/LeftMenuButton.vue
+++ b/frontend/src/components/leftMenu/LeftMenuButton.vue
@@ -1,10 +1,8 @@
 <template>
-  <v-col>
-    <v-btn rounded text v-on:click="onClick">
-      <v-icon> {{ btnIcon }} </v-icon>
-      {{ btnText }}
-    </v-btn>
-  </v-col>
+  <v-btn  class="ma-0 pa-0" rounded text v-on:click="onClick">
+    <v-icon> {{ btnIcon }} </v-icon>
+    {{ btnText }}
+  </v-btn>
 </template>
 
 <script>

--- a/frontend/src/components/leftMenu/LeftMenuButton.vue
+++ b/frontend/src/components/leftMenu/LeftMenuButton.vue
@@ -1,9 +1,22 @@
 <template>
-  <v-btn  class="ma-0 pa-0" rounded text v-on:click="onClick">
+  <v-btn
+    class="ma-0 pa-0 leftMenuBtn"
+    color="#CFD8DC"
+    rounded
+    x-large
+    :elevation="3"
+    v-on:click="onClick"
+  >
     <v-icon> {{ btnIcon }} </v-icon>
     {{ btnText }}
   </v-btn>
 </template>
+
+<style>
+.leftMenuBtn {
+  width: 175px;
+}
+</style>
 
 <script>
 export default {

--- a/frontend/src/components/mainContents/DisplayHomete.vue
+++ b/frontend/src/components/mainContents/DisplayHomete.vue
@@ -1,9 +1,8 @@
 <template>
   <v-container fluid>
-    <v-card outlined>
-      <h4 class="ml-4 mt-2">匿名さん</h4>
-      <v-divider class="mx-4"></v-divider>
-      <v-card-text class="black--text">
+    <v-card class="hometeCard rounded-xl" :elevation="3">
+      <h3 class="ml-4 mt-2">とくめいさん</h3>
+      <v-card-text class="cardText black--text font-weight-light">
         {{ homete }}
       </v-card-text>
       <v-card-actions>
@@ -22,6 +21,19 @@
   </v-container>
 </template>
 <style>
+.hometeCard{
+  margin: 0;
+  width: 100%;
+  min-width: 520px;
+  max-width: 520px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 20px;
+}
+.cardText{
+  font-size: 18px;
+  line-height: 26px;
+}
 .horizontalListWide {
   /* 縦スクロール設定 */
   overflow: auto;

--- a/frontend/src/components/mainContents/TimeLine.vue
+++ b/frontend/src/components/mainContents/TimeLine.vue
@@ -1,8 +1,6 @@
 <template>
   <v-col
-    sm="8"
-    md="8"
-    class="subContainer virtualScrollBar"
+    class="mainContents virtualScrollBar"
     v-scroll="onScroll"
   >
     <DisplayHomete v-for="post in posts" :key="post.post_id" :postList="post" />
@@ -11,8 +9,14 @@
 </template>
 
 <style>
-.subContainer {
-  width: 100%;
+.mainContents {
+  margin: 0 auto;
+  margin-top: 47px;
+  margin-bottom: 20px;
+  padding: 0;
+  width: 550px;
+  min-width: 550px;
+  max-width: 550px;
 }
 .virtualScrollBar {
   overflow: auto;

--- a/frontend/src/components/rightMenu/RightMenu.vue
+++ b/frontend/src/components/rightMenu/RightMenu.vue
@@ -1,0 +1,60 @@
+<template>
+  <v-col class="rightMenu">
+    <div class="postBtn">
+      <button class="postBtnTxt"><v-icon>mdi-pen-plus</v-icon>投稿する</button>
+    </div>
+    <div class="ruleBtn">
+      <button class="ruleBtnTxt">利用規約</button>
+    </div>
+  </v-col>
+</template>
+<style>
+.rightMenu {
+  display: flex;
+  flex-flow: column;
+  height: 100vh;
+  min-height: 100vh;
+  max-height: 100vh;
+  margin: 0;
+  padding: 0;
+}
+.postBtn {
+  margin-left: auto;
+  margin-top: 60vh;
+  text-align: center;
+  width: 175px;
+  height: 75px;
+  border-radius: 30px;
+  background-color: #cfd8dc;
+  box-shadow: 1px 3px 2px 1px rgba(0, 0, 0, 0.3);
+}
+.postBtnTxt {
+  font-size: 18px;
+  line-height: 75px;
+}
+.ruleBtn {
+  margin-left: auto;
+  margin-top: 15vh;
+  text-align: center;
+  width: 105px;
+  height: 20px;
+  border-radius: 30px;
+  background-color: #cfd8dc;
+  box-shadow: 1px 3px 2px 1px rgba(0, 0, 0, 0.3);
+}
+.ruleBtnTxt {
+  font-size: 12px;
+  line-height: 20px;
+}
+</style>
+
+<script>
+export default {
+  name: "RightMenu",
+  computed: {
+    isVisiblePostHomete() {
+      return this.$store.getters.isVisiblePostHomete;
+    },
+  },
+};
+</script>

--- a/frontend/src/components/util/Footer.vue
+++ b/frontend/src/components/util/Footer.vue
@@ -3,7 +3,7 @@
     style="border-top: solid #00000080 2px"
     class="footer"
     color="#BABDBE"
-    absolute
+    fixed
     padless
   >
     <v-col class="text-center ftTxt" cols="12">

--- a/frontend/src/components/util/Header.vue
+++ b/frontend/src/components/util/Header.vue
@@ -1,6 +1,7 @@
 <template>
   <v-app-bar
-    style="border-bottom: solid #00000080 2px"
+    style="border-bottom: solid #00000080 2px;"
+    :height="50"
     color="#BABDBE"
     fixed
     dense
@@ -9,11 +10,11 @@
     <v-toolbar-title class="text-h5 font-weight-bold title">
       homete…
     </v-toolbar-title>
-    <v-btn class="accountBtn" color="#CFD8DC" rounded v-if="isLogin">
+    <v-btn class="headerBtn" color="#CFD8DC" rounded v-if="isLogin">
       <v-icon color="#494854">mdi-account-cog</v-icon><div>アカウント</div>
     </v-btn>
     <v-btn
-      class="loginBtn"
+      class="headerBtn"
       color="#CFD8DC"
       rounded
       @click="login"
@@ -29,11 +30,7 @@
   margin-left: 5%;
   color: #494854;
 }
-.accountBtn {
-  margin-left: auto;
-  margin-right: 5%;
-}
-.loginBtn {
+.headerBtn {
   margin-left: auto;
   margin-right: 5%;
 }

--- a/frontend/src/components/util/Header.vue
+++ b/frontend/src/components/util/Header.vue
@@ -2,7 +2,7 @@
   <v-app-bar
     style="border-bottom: solid #00000080 2px"
     color="#BABDBE"
-    absolute
+    fixed
     dense
     elevation="0"
   >

--- a/frontend/src/views/Top.vue
+++ b/frontend/src/views/Top.vue
@@ -12,9 +12,9 @@
     <v-container class="contents mx-auto">
       <Alert />
       <v-row justify="center" class="contentsFlex mx-auto my-auto">
-        <LeftMenu class="SideMenuSticky" v-on:logout="isLoginCheck" />
+        <LeftMenu class="SideMenuSticky" />
         <TimeLine />
-        <v-col class="ma-0 pa-0"> </v-col>
+        <RightMenu class="SideMenuSticky" />
       </v-row>
     </v-container>
     <Footer />
@@ -27,7 +27,7 @@
   margin: 0;
   padding: 0;
 }
-.contents{
+.contents {
   width: 1000px;
   margin: 0;
   padding: 0;
@@ -43,12 +43,13 @@
 
 
 <script>
-import LeftMenu from "../components/leftMenu/LeftMenu.vue";
-import TimeLine from "../components/mainContents/TimeLine.vue";
-import Alert from "../components/util/Alert.vue";
-import Footer from "../components/util/Footer.vue";
-import Header from "../components/util/Header.vue";
-import PostHomete from "../components/util/PostHomete.vue";
+import LeftMenu from "@/components/leftMenu/LeftMenu.vue";
+import TimeLine from "@/components/mainContents/TimeLine.vue";
+import RightMenu from "@/components/rightMenu/RightMenu.vue";
+import Alert from "@/components/util/Alert.vue";
+import Footer from "@/components/util/Footer.vue";
+import Header from "@/components/util/Header.vue";
+import PostHomete from "@/components/util/PostHomete.vue";
 
 export default {
   name: "Top",
@@ -63,6 +64,7 @@ export default {
   components: {
     LeftMenu,
     TimeLine,
+    RightMenu,
     Alert,
     Footer,
     Header,
@@ -81,8 +83,8 @@ export default {
     if (this.$cookies.isKey("expire") == true) {
       this.$store.dispatch("toTrueLogin");
       setTimeout(() => {
-          this.$store.dispatch("alertLogin");
-        }, 1500);
+        this.$store.dispatch("alertLogin");
+      }, 1500);
     } else {
       this.$store.dispatch("toFalseLogin");
     }

--- a/frontend/src/views/Top.vue
+++ b/frontend/src/views/Top.vue
@@ -13,9 +13,7 @@
       <Alert />
       <v-row justify="center" class="contentsFlex mx-auto my-auto">
         <LeftMenu class="SideMenuSticky" v-on:logout="isLoginCheck" />
-        <v-divider vertical />
         <TimeLine />
-        <v-divider vertical />
         <v-col class="ma-0 pa-0"> </v-col>
       </v-row>
     </v-container>
@@ -31,18 +29,15 @@
 }
 .contents{
   width: 1000px;
-  border: solid black 3px;
   margin: 0;
   padding: 0;
-  margin-top: 47px;
-  margin-bottom: 20px;
 }
 .contentsFlex {
   display: flex;
 }
 .SideMenuSticky {
   position: sticky;
-  top: 47px;
+  top: 0;
 }
 </style>
 

--- a/frontend/src/views/Top.vue
+++ b/frontend/src/views/Top.vue
@@ -11,8 +11,8 @@
     </v-overlay>
     <v-container class="contents mx-auto">
       <Alert />
-      <v-row justify="center" class="mx-auto my-auto wrapper">
-        <LeftMenu class="widget--sticky" v-on:logout="isLoginCheck" />
+      <v-row justify="center" class="contentsFlex mx-auto my-auto">
+        <LeftMenu class="SideMenuSticky" v-on:logout="isLoginCheck" />
         <v-divider vertical />
         <TimeLine />
         <v-divider vertical />
@@ -37,14 +37,12 @@
   margin-top: 47px;
   margin-bottom: 20px;
 }
-.wrapper {
-  margin: 0;
+.contentsFlex {
   display: flex;
-  justify-content: space-between;
 }
-.widget--sticky {
+.SideMenuSticky {
   position: sticky;
-  top: 50px;
+  top: 47px;
 }
 </style>
 

--- a/frontend/src/views/Top.vue
+++ b/frontend/src/views/Top.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app>
+  <v-app class="artBoard">
     <Header />
     <v-overlay
       :value="isVisiblePostHomete"
@@ -9,10 +9,10 @@
     >
       <PostHomete />
     </v-overlay>
-    <v-container fluid class="mainContainer mx-auto">
+    <v-container class="contents mx-auto">
       <Alert />
-      <v-row justify="center" class="mx-auto">
-        <LeftMenu class="leftMenuContent" v-on:logout="isLoginCheck" />
+      <v-row justify="center" class="mx-auto my-auto wrapper">
+        <LeftMenu class="widget--sticky" v-on:logout="isLoginCheck" />
         <v-divider vertical />
         <TimeLine />
         <v-divider vertical />
@@ -23,14 +23,28 @@
   </v-app>
 </template>
 <style>
-.mainContainer {
-  max-width: 1200px;
+.artBoard {
   width: 100%;
   height: 100%;
+  margin: 0;
+  padding: 0;
 }
-.leftMenuContent {
+.contents{
+  width: 1000px;
+  border: solid black 3px;
+  margin: 0;
+  padding: 0;
+  margin-top: 47px;
+  margin-bottom: 20px;
+}
+.wrapper {
+  margin: 0;
+  display: flex;
+  justify-content: space-between;
+}
+.widget--sticky {
   position: sticky;
-  top: 0px;
+  top: 50px;
 }
 </style>
 


### PR DESCRIPTION
- 投稿一覧表示部分、左右メニューの幅調整
- 投稿一覧表示部分、左右メニューを今後変更しやすいようにmargin、padding周りを整理
- ヘッダーの縦幅調整
- 左右メニューのボタン配置
- 投稿一覧に使用しているv-cardの幅調整
- v-card内の文字サイズや文字の太さ、行間の幅を調整